### PR TITLE
Spectra generation

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h
@@ -61,7 +61,8 @@ class OPENMS_DLLAPI Deisotoper
     subclusters starting at the base peak as well), the largest one with the 
     highest charge is kept.
 
-    Deisotoping is done in-place, and if @p rem_low_intensity is true,
+    Deisotoping is done in-place, and the algorithm removes peaks with 
+    intensity 0. If @p rem_low_intensity is true,
     peaks not belonging to the highest 1000/5000 peaks are removed (see 
     @p used_for_open_search). If @p annotate_charge is true,
     an additional IntegerDataArray "charge" will be appended. If
@@ -83,7 +84,7 @@ class OPENMS_DLLAPI Deisotoper
    * @param [annotate_iso_peak_count] Annotate the number of isotopic peaks in a pattern for each monoisotopic peak in the IntegerDataArray: "iso_peak_count"
    * @param [use_averagine_model] Compares observed patterns with theoretical averagine distributions using KL-divergence. If false, no intensity checks are applied.
    * @param [add_up_intensity] Sum up the total intensity of each isotopic pattern into the intensity of the reported monoisotopic peak
-   * @param [rem_low_intensity] Only keep the 1000 or 5000 (see @p used_for_open_search ) most intense peaks in the spectrum. Also removes peaks with intensity 0.
+   * @param [rem_low_intensity] Only keep the 1000 or 5000 (see @p used_for_open_search ) most intense peaks in the spectrum.
    * @param [used_for_open_search] If true, all but the 1000 most intense peaks are removed, else 5000 peaks are kept
    */
     static void deisotopeWithAveragineModel(MSSpectrum& spectrum,

--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h
@@ -95,7 +95,7 @@ class OPENMS_DLLAPI Deisotoper
       int max_charge = 3,
       bool keep_only_deisotoped = false,
       unsigned int min_isopeaks = 2,
-      unsigned int max_isopeaks = 10,
+      unsigned int max_isopeaks = 7,
       bool make_single_charged = true,
       bool use_averagine_model = true,
       bool annotate_charge = false,

--- a/src/tests/class_tests/openms/data/Deisotoper_test_out.mzML
+++ b/src/tests/class_tests/openms/data/Deisotoper_test_out.mzML
@@ -59,7 +59,7 @@
 	</dataProcessingList>
 	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0">
 		<spectrumList count="1" defaultDataProcessingRef="dp_sp_0">
-			<spectrum id="controllerType=0 controllerNumber=1 scan=2" index="0" defaultArrayLength="104" dataProcessingRef="dp_sp_0">
+			<spectrum id="controllerType=0 controllerNumber=1 scan=2" index="0" defaultArrayLength="105" dataProcessingRef="dp_sp_0">
 				<cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" />
 				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
 				<cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
@@ -86,17 +86,17 @@
 					</scan>
 				</scanList>
 				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="1112">
+					<binaryDataArray encodedLength="1120">
 						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
 						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
 						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>jvQpnlLfckBLDCPBoFNzQDz06nfjX3NATz5lfv2ec0AHDsIgNbBzQAOt117eznNAYw3EruTPc0D6Lp4eMzF0QJyRXy04T3RAm+IKAyFwdEC9IlJwE5B0QCR257MHsHRATex6xcrOdECB12tfH791QMw/OnwH0HVAL0yytDffdUD0TkCk+u91QGYsyAAI/3VAoczbHxgQdkCKLyKipG92QDPCT42i73ZAnxJgedL+dkDVn+ufjw93QCzNMmO+D3dADfozbGkvd0DfZy2DCDV3QH1KnTRTUHdACTBmVDsPeEDG+K02CxR4QMZ8whjQHnhAPHt0NyIweEBsKvZte0V4QHI1qXf1TnhAJ4OEWYNPeEDddNKI5294QEnJEqiOdHhAZQMxOIt/eEC9NmM2aZB4QDBB5afjvnhAbfnwZs7eeECIMAiuIQ95QP04sUXAHnlASA2+BJQfeUB4f2RPrT55QGD0/X1bUHlASZuWH01weUDI47Hlh395QEHD9edDkHlAesRldQGveUDCq6Iq1K95QNvgaf89/3lAX+iNAdH/eUCjBcuVDjV6QMBmig4rP3pA5E5gpN9DekAImi6ZzpV6QO+z8B6+r3pA1KmE6BC2ekDJlm426r56QE3aqIByv3pAbTMjCx/fekCtCLRs95J7QMohwWPp0XtA3p0ukon1e0BE0pa/izB8QAaIe+xX4nxAk/+kLEwCfUBGQRupH1B9QOkcPRbpv31ANYl50l7vfUDhDnUQyP99QJ/HU1r1L35AuYb0daKOfkAoE1DIah9/QMca4M0egH9A+gliLs+ff0APpSpHGqB/QLEg2WIeOYBATIReIr5fgEBDaSvMUcGAQGsNdLlO0YBAM3WUEenngEAq5ZU3fi+BQNR6Y+fKD4JA7KaMunwRg0CX+NmR3heDQAilX1KQHYRAwA/D89kvhEA46025X2+EQE85+SyiYYVAZFhDYfxXhkDyIEgNxLGHQGSSkByooYlAi2R5w9Dpi0DmsSiFDamOQN2PJctoR5BACva/3Rl7kkAgb21fsRyUQOdpMZLMzpVApSegwuKylkC1yosq39yYQBiUUYDtJ5xAfCZUb0osnkAZCQpOEragQA==</binary>
+						<binary>jvQpnlLfckBLDCPBoFNzQDz06nfjX3NATz5lfv2ec0AHDsIgNbBzQAOt117eznNAYw3EruTPc0D6Lp4eMzF0QJyRXy04T3RAm+IKAyFwdEC9IlJwE5B0QCR257MHsHRATex6xcrOdECB12tfH791QMw/OnwH0HVAL0yytDffdUD0TkCk+u91QGYsyAAI/3VAoczbHxgQdkCKLyKipG92QDPCT42i73ZAnxJgedL+dkDVn+ufjw93QCzNMmO+D3dADfozbGkvd0DfZy2DCDV3QH1KnTRTUHdACTBmVDsPeEDG+K02CxR4QMZ8whjQHnhAPHt0NyIweEBsKvZte0V4QHI1qXf1TnhAJ4OEWYNPeEDddNKI5294QEnJEqiOdHhAZQMxOIt/eEC9NmM2aZB4QDBB5afjvnhAbfnwZs7eeECIMAiuIQ95QP04sUXAHnlASA2+BJQfeUB4f2RPrT55QGD0/X1bUHlASZuWH01weUDI47Hlh395QEHD9edDkHlAesRldQGveUDCq6Iq1K95QNvgaf89/3lAX+iNAdH/eUCjBcuVDjV6QMBmig4rP3pA5E5gpN9DekAImi6ZzpV6QO+z8B6+r3pA1KmE6BC2ekDJlm426r56QE3aqIByv3pAbTMjCx/fekCtCLRs95J7QMohwWPp0XtA3p0ukon1e0BE0pa/izB8QAaIe+xX4nxAk/+kLEwCfUBGQRupH1B9QOkcPRbpv31ANYl50l7vfUDhDnUQyP99QJ/HU1r1L35AuYb0daKOfkAoE1DIah9/QMca4M0egH9A+gliLs+ff0APpSpHGqB/QLEg2WIeOYBATIReIr5fgEBDaSvMUcGAQGsNdLlO0YBAM3WUEenngEAq5ZU3fi+BQNR6Y+fKD4JA7KaMunwRg0CX+NmR3heDQAilX1KQHYRAwA/D89kvhEA46025X2+EQE85+SyiYYVAZFhDYfxXhkDyIEgNxLGHQGSSkByooYlAi2R5w9Dpi0DmsSiFDamOQN2PJctoR5BAyRDALvGCkEAK9r/dGXuSQCBvbV+xHJRA52kxkszOlUClJ6DC4rKWQLXKiyrf3JhAGJRRgO0nnEB8JlRvSiyeQBkJCk4StqBA</binary>
 					</binaryDataArray>
-					<binaryDataArray encodedLength="556">
+					<binaryDataArray encodedLength="560">
 						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
 						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
 						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>GO2+Rk7Lj0edxcFFsAIzR7QEfUZjVwZH8+iARznNYEZFz4hHaQvwSJiw7EjyQiBIWSggSOTObkeVb0hJuv0yR8ipz0c2Q8BGWsgKR4CZbka+QCRJ4B7tRo1nmkftTjVIKz6hRqxcJ0hjiQNIZr9nR3itlEZ57BtGRkI5RtYgQEfkemdFz4wuRv9YxUeXgvxHBE8NR4i/wUbhENZHp/CFRgQn4kZ5Rg1IExDNRzQVsUbZjYNIYKqCSLgCREgUo65HZSyHRp/vt0XL37NGipx1RjC0GUfsqElHK8aMRspmRUaH31tHMBkzRjpgekWpb5RGWXarRenaLkZXTu1FyNJWSAlkiEcmghhHJSvjRefEmEeTYJ5F/LeRR3DtjUeeuUhGM822RYfXA0cos6ZHAROMRlxoGEYzh6ZFoP3DRqUWGkc8SUtGXwx+RjBEVUYcS49FEWBhRvpuBUcm7cpFXL0gRQfNjEXAUgpGt0j2RZ84g0WudJxF3D94RW+GlUVqATpFerAFRTgOeEWz0INGqAfFRbpZkkWI6uxE5HYERVmW2kQ=</binary>
+						<binary>GO2+Rk7Lj0edxcFFsAIzR7QEfUZjVwZH8+iARznNYEZFz4hHaQvwSJiw7EjyQiBIWSggSOTObkeVb0hJuv0yR8ipz0c2Q8BGWsgKR4CZbka+QCRJ4B7tRo1nmkftTjVIKz6hRqxcJ0hjiQNIZr9nR3itlEZ57BtGRkI5RtYgQEfkemdFz4wuRv9YxUeXgvxHBE8NR4i/wUbhENZHp/CFRgQn4kZ5Rg1IExDNRzQVsUbZjYNIYKqCSLgCREgUo65HZSyHRp/vt0XL37NGipx1RjC0GUfsqElHK8aMRspmRUaH31tHMBkzRjpgekWpb5RGWXarRenaLkZXTu1FyNJWSAlkiEcmghhHJSvjRefEmEeTYJ5F/LeRR3DtjUeeuUhGM822RYfXA0cos6ZHAROMRlxoGEYzh6ZFoP3DRqUWGkc8SUtGXwx+RjBEVUYcS49FEWBhRvpuBUcm7cpFXL0gRQfNjEXAUgpGt0j2RZ84g0WudJxF3D94RW+GlUVqATpFSuS0RXqwBUU4DnhFs9CDRqgHxUW6WZJFiOrsROR2BEVZltpE</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</spectrum>
@@ -108,6 +108,6 @@
 		<offset idRef="controllerType=0 controllerNumber=1 scan=2">3816</offset>
 	</index>
 </indexList>
-<indexListOffset>8726</indexListOffset>
+<indexListOffset>8738</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -121,7 +121,6 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
    TEST_REAL_SIMILAR(theo0[0].getMZ(), 100); 
    TEST_REAL_SIMILAR(theo0[1].getMZ(), 400.0 - Constants::PROTON_MASS_U); 
 
-
    // create a theoretical spectrum generator 
    // and configure to add isotope patterns
    TheoreticalSpectrumGenerator spec_generator;
@@ -154,141 +153,169 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
    MSSpectrum theo1_noiso;
    spec_generator.getSpectrum(theo1_noiso, peptide1, 1, 2); // charge 1..2
    TEST_EQUAL(theo1.size(), theo1_noiso.size()); // same number of peaks after deisotoping
+}
+END_SECTION
 
-   // NEW ALGORTIHM TESTS
-   // spectrum with one isotopic pattern
-   MSSpectrum spec;
-   CoarseIsotopePatternGenerator gen(5);
-   IsotopeDistribution distr = gen.estimateFromPeptideWeight(700);
-   double base_mz1 = distr[0].getMZ();
-   for (auto it = distr.begin(); it != distr.end(); ++it)
-   {
-	 if (it->getIntensity() != 0)
-	 {
-	   spec.push_back(*it);
-	 }
-   }
-   spec.sortByPosition();
-   MSSpectrum theo(spec);
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
-   TEST_EQUAL(theo.size(), 1);
-   TEST_REAL_SIMILAR(theo[0].getMZ(), base_mz1);
-   
-   // Peaks before and after spectrum should not be chosen
-   // Shows a fault of the old algorithm occurring with e.g. deamination
-   double correct_monoiso = theo.getBasePeak()->getMZ();
-   double deamin_mz = spec.front().getMZ() - OpenMS::Constants::NEUTRON_MASS_U;
-   Peak1D deamin_peak = Peak1D(deamin_mz, 0.01f);
-   spec.push_back(deamin_peak);
-   spec.sortByPosition();
-   theo = spec;
-   theo1 = spec;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true); //keep only deisotoped
-   TEST_REAL_SIMILAR(theo.front().getMZ(), correct_monoiso);
-   Deisotoper::deisotopeAndSingleCharge(theo1, 10.0, true, 1, 3, true);
-   TEST_NOT_EQUAL(theo1.front().getMZ(), correct_monoiso); // passes -> not equal
+START_SECTION(static void deisotopeWithAveragineModel(MSSpectrum& spectrum,
+                                                      double fragment_tolerance,
+                                                      bool fragment_unit_ppm,
+                                                      bool rem_low_intensity = true,
+                                                      int min_charge = 1,
+                                                      int max_charge = 3,
+                                                      bool keep_only_deisotoped = false))
+{
+  // spectrum with one isotopic pattern
+  MSSpectrum spec;
+  CoarseIsotopePatternGenerator gen(5);
+  IsotopeDistribution distr = gen.estimateFromPeptideWeight(700);
+  double base_mz1 = distr[0].getMZ();
+  for (auto it = distr.begin(); it != distr.end(); ++it)
+  {
+    if (it->getIntensity() != 0)
+    {
+      it->setIntensity(it->getIntensity() * 10);
+      spec.push_back(*it);
+    }
+  }
+  spec.sortByPosition();
+  MSSpectrum theo(spec);
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
+  TEST_EQUAL(theo.size(), 1);
+  TEST_REAL_SIMILAR(theo[0].getMZ(), base_mz1);
 
-   // Test a peak with zero intensitiy
-   double add_mz = spec.back().getMZ() + OpenMS::Constants::C13C12_MASSDIFF_U;
-   Peak1D add_peak(add_mz, 0.0);
-   spec.push_back(add_peak);
-   theo = spec;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
-   TEST_NOT_EQUAL(theo.back().getIntensity(), 0.0);// the new peak should be removed
-   
-   // Additional peaks that only fit m/z - wise should not disturb cluster formation
-   spec.back().setIntensity(2); // intensity is a lot too high to fit correct distribution
-   theo = spec;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, false); // do not remove low intensities
-   TEST_EQUAL(theo.size(), 3);
-   TEST_REAL_SIMILAR(theo.back().getMZ(), add_mz); // last peak is still there
-   
-   // spectrum with two isotopic patterns
-   distr = gen.estimateFromPeptideWeight(500);
-   double base_mz2 = distr[0].getMZ();
-   for (auto it = distr.begin(); it != distr.end(); ++it)
-   {
-	 if (it->getIntensity() != 0)
-	 {
-	   it->setMZ((it->getMZ() + OpenMS::Constants::PROTON_MASS_U) / 2); // set to charge 2
-	   spec.push_back((*it));
-	 }
-   }
-   theo = spec;
-   theo.sortByPosition();
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true); // keep only deisotoped
-   TEST_EQUAL(theo.size(), 2);
-   TEST_EQUAL(theo[0].getMZ(), base_mz2);
-   TEST_EQUAL(theo[1].getMZ(), base_mz1);
+  // Peaks before and after spectrum should not be chosen
+  // Shows a fault of the old algorithm occurring with e.g. deamination
+  double correct_monoiso = theo.getBasePeak()->getMZ();
+  double deamin_mz = spec.front().getMZ() - OpenMS::Constants::NEUTRON_MASS_U;
+  Peak1D deamin_peak = Peak1D(deamin_mz, 0.06f);
+  spec.push_back(deamin_peak);
+  spec.sortByPosition();
+  theo = spec;
+  MSSpectrum theo1(spec);
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);//keep only deisotoped
+  TEST_REAL_SIMILAR(theo.front().getMZ(), correct_monoiso);
+  Deisotoper::deisotopeAndSingleCharge(theo1, 10.0, true, 1, 3, true);
+  TEST_NOT_EQUAL(theo1.front().getMZ(), correct_monoiso);// passes -> not equal
 
-   // Add unassignable peaks
-   Peak1D peak1(550, 0.8f);
-   spec.push_back(peak1);
-   Peak1D peak2(600, 0.9f);
-   spec.push_back(peak2);
-   spec.sortByPosition();
-   theo = spec;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, false); // do not remove low intensities
-   TEST_EQUAL(theo.size(), 6); // two spectra, one peak before, one after one spectrum, and two unassignable peaks
+  // Test a peak with zero intensitiy
+  double add_mz = spec.back().getMZ() + OpenMS::Constants::C13C12_MASSDIFF_U;
+  Peak1D add_peak(add_mz, 0.0);
+  spec.push_back(add_peak);
+  theo = spec;
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
+  TEST_NOT_EQUAL(theo.back().getIntensity(), 0.0);// the new peak should be removed
 
-   // keep only deisotoped
-   theo = spec;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);
-   TEST_EQUAL(theo.size(), 2);
+  // Additional peaks that only fit m/z - wise should not disturb cluster formation
+  spec.back().setIntensity(20);// intensity is a lot too high to fit correct distribution
+  theo = spec;
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, false);// do not remove low intensities
+  TEST_EQUAL(theo.size(), 3);
+  TEST_REAL_SIMILAR(theo.back().getMZ(), add_mz);// last peak is still there
 
-   // test with complete theoretical spectrum
-   param.setValue("isotope_model", "coarse");
-   spec_generator.setParameters(param);
-   theo.clear(true);
-   spec_generator.getSpectrum(theo, peptide1, 1, 2); // charge 1..2
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
-   // create theoretical spectrum without isotopic peaks for comparison to the deisotoped one
-   param.setValue("isotope_model", "none");  // disable additional isotopes
-   spec_generator.setParameters(param);
-   MSSpectrum theo_noiso;
-   spec_generator.getSpectrum(theo_noiso, peptide1, 1, 2); // charge 1..2
-   TEST_EQUAL(theo.size(), theo_noiso.size()); // same number of peaks after deisotoping
+  // spectrum with two isotopic patterns
+  distr = gen.estimateFromPeptideWeight(500);
+  double base_mz2 = distr[0].getMZ();
+  for (auto it = distr.begin(); it != distr.end(); ++it)
+  {
+    if (it->getIntensity() != 0)
+    {
+      it->setMZ((it->getMZ() + OpenMS::Constants::PROTON_MASS_U) / 2);// set to charge 2
+      spec.push_back((*it));
+    }
+  }
+  theo = spec;
+  theo.sortByPosition();
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);// keep only deisotoped
+  TEST_EQUAL(theo.size(), 2);
+  TEST_EQUAL(theo[0].getMZ(), base_mz2);
+  TEST_EQUAL(theo[1].getMZ(), base_mz1);
 
-   // two patterns where all isotopic peaks have the same intensity
-   two_patterns.clear(true);
-   p.setIntensity(1.0);
+  // Add unassignable peaks
+  Peak1D peak1(550, 0.8f);
+  spec.push_back(peak1);
+  Peak1D peak2(600, 0.9f);
+  spec.push_back(peak2);
+  spec.sortByPosition();
+  theo = spec;
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, false);// do not remove low intensities
+  TEST_EQUAL(theo.size(), 6);                                      // two spectra, one peak before, one after one spectrum, and two unassignable peaks
 
-   // first pattern
-   p.setMZ(100.0);
-   two_patterns.push_back(p);
-   p.setMZ(100.0 + Constants::C13C12_MASSDIFF_U);
-   two_patterns.push_back(p);
-   p.setMZ(100.0 + 2.0 * Constants::C13C12_MASSDIFF_U);
-   two_patterns.push_back(p);
+  // keep only deisotoped
+  theo = spec;
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);
+  TEST_EQUAL(theo.size(), 2);
 
-   // second pattern
-   p.setMZ(200.0);
-   two_patterns.push_back(p);
-   p.setMZ(200.0 + 0.5 * Constants::C13C12_MASSDIFF_U);
-   two_patterns.push_back(p);
-   p.setMZ(200.0 + 2.0 * 0.5 * Constants::C13C12_MASSDIFF_U);
-   two_patterns.push_back(p);
-   theo = two_patterns;
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
-   TEST_EQUAL(theo.size(), 6); // all six peaks remain, since the patterns should not be similar to averagine model
+  // test with complete theoretical spectrum
 
-   // Test with a section of an actual spectrum
-   MzMLFile file;
-   PeakMap exp;
-   file.load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_test_in.mzML"), exp);
-   theo.clear(true);
-   theo = exp.getSpectrum(0);// copy for readability
-   theo1.clear(true);
-   theo1 = exp.getSpectrum(0);// for next test
-   Size ori_size = theo.size();
-   Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);// keep only deisotoped
-   TEST_NOT_EQUAL(theo.size(), ori_size);
-   file.load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_test_out.mzML"), exp);
-   TEST_EQUAL(theo, exp.getSpectrum(0));
+  // create a theoretical spectrum generator
+  // and configure to add isotope patterns
+  TheoreticalSpectrumGenerator spec_generator;
+  Param param = spec_generator.getParameters();
+  param.setValue("isotope_model", "coarse");
+  param.setValue("max_isotope", 3);
+  param.setValue("add_a_ions", "false");
+  param.setValue("add_b_ions", "false");
+  param.setValue("add_losses", "false");
+  param.setValue("add_precursor_peaks", "false");
+  spec_generator.setParameters(param);
+  param.setValue("isotope_model", "coarse");
+  spec_generator.setParameters(param);
 
-   // Test if the algorithm also works if we do not remove the low (and zero) intensity peaks
-   Deisotoper::deisotopeWithAveragineModel(theo1, 10.0, true, false, 1, 3, true); // do not remove low intensity peaks beforehand
-   TEST_EQUAL(theo1.size(), 103);
+  AASequence peptide1 = AASequence::fromString("PEPTIDE");
+
+  theo.clear(true);
+  spec_generator.getSpectrum(theo, peptide1, 1, 2);// charge 1..2
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
+
+  // create theoretical spectrum without isotopic peaks for comparison to the deisotoped one
+  param.setValue("isotope_model", "none");// disable additional isotopes
+  spec_generator.setParameters(param);
+  MSSpectrum theo_noiso;
+  spec_generator.getSpectrum(theo_noiso, peptide1, 1, 2);// charge 1..2
+  TEST_EQUAL(theo.size(), theo_noiso.size());            // same number of peaks after deisotoping
+
+  // simpler tests with patterns where all isotopic peaks have the same intensity
+  MSSpectrum two_patterns;
+  Peak1D p;
+  two_patterns.clear(true);
+  p.setIntensity(1.0);
+
+  // first pattern
+  p.setMZ(100.0);
+  two_patterns.push_back(p);
+  p.setMZ(100.0 + Constants::C13C12_MASSDIFF_U);
+  two_patterns.push_back(p);
+  p.setMZ(100.0 + 2.0 * Constants::C13C12_MASSDIFF_U);
+  two_patterns.push_back(p);
+
+  // second pattern
+  p.setMZ(200.0);
+  two_patterns.push_back(p);
+  p.setMZ(200.0 + 0.5 * Constants::C13C12_MASSDIFF_U);
+  two_patterns.push_back(p);
+  p.setMZ(200.0 + 2.0 * 0.5 * Constants::C13C12_MASSDIFF_U);
+  two_patterns.push_back(p);
+  theo = two_patterns;
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true);
+  TEST_EQUAL(theo.size(), 6);// all six peaks remain, since the patterns should not be similar to averagine model
+
+  // Test with a section of an actual spectrum
+  MzMLFile file;
+  PeakMap exp;
+  file.load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_test_in.mzML"), exp);
+  theo.clear(true);
+  theo = exp.getSpectrum(0);// copy for readability
+  theo1.clear(true);
+  theo1 = exp.getSpectrum(0);// for next test
+  Size ori_size = theo.size();
+  Deisotoper::deisotopeWithAveragineModel(theo, 10.0, true, true, 1, 3, true);// keep only deisotoped
+  TEST_NOT_EQUAL(theo.size(), ori_size);
+  file.load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_test_out.mzML"), exp);
+  TEST_EQUAL(theo, exp.getSpectrum(0));
+
+  // Test if the algorithm also works if we do not remove the low (and zero) intensity peaks
+  Deisotoper::deisotopeWithAveragineModel(theo1, 10.0, true, false, 1, 3, true);// do not remove low intensity peaks beforehand, but keep only deisotoped
+  TEST_EQUAL(theo1.size(), 105);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -319,6 +319,40 @@ START_SECTION(static void deisotopeWithAveragineModel(MSSpectrum& spectrum,
 }
 END_SECTION
 
+START_SECTION(BENCHMARKING)
+{
+  // ****** BENCHMARKING ****** //
+  // Generate spectra for benchmarking
+  // Generate spectrum deisotoped by original algorithm
+
+  String path = "C:/Users/emilp/Documents/Projekte/HiWi/data/SSE_Benchmarking/";
+  String str1 = "Starting new algorithm on spectrum ";
+  String str2 = " of ";
+  String lb = "\n";
+
+  MzMLFile file;
+  PeakMap exp;
+
+  std::cerr << "start loading spectra\n";
+  unsigned int count = 0;
+  file.load(path + "B1.mzML", exp);
+  Size num_spectra = exp.size();
+  std::cerr << "finished loading spectra\n";
+
+  for (auto it = exp.begin(); it != exp.end(); ++it)
+  {
+    if (count % 100 == 1)
+    {
+      std::cerr << str1 << (String) count << str2 << (String) num_spectra << lb;
+    }
+    Deisotoper::deisotopeWithAveragineModel(*it, 10.0, true, true, 1, 3, true);
+    count++;
+  }
+
+  file.store(path + "out_spectra_generation.mzML", exp);
+  TEST_NOT_EQUAL(exp.size(), 0);
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description
- Spectra are now generated once per cluster, not for every extension
- Theoretical idotope distribution is now approximated using a Poisson distribution, similar to Bellew et al (https://dx.doi.org/10.1093/bioinformatics/btl276)
- Reduced computation time by a factor of at least 50
- Benchmarking with other datasets (https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Tutorials/Data/iPRG2015_Hannes/) shows good results if keep_only_deisotoped = false, also after using this approximation:
![current_version](https://user-images.githubusercontent.com/57809013/130983604-01f5da14-27cd-4df4-b84c-eecad36cfaec.png)
